### PR TITLE
Update Gem dependencies as filter works fine with Logstash 6.8.7

### DIFF
--- a/logstash-filter-docker_container.gemspec
+++ b/logstash-filter-docker_container.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-docker_container'
-  s.version = '0.2.1'
+  s.version = '0.2.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Resolves Docker container IDs into the container's name."
   s.description = "With Docker's syslog log-driver the log entries contain just container ID, but seeing the name is even better"
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 5.0.0', '< 5.6.0'
+  s.add_runtime_dependency "logstash-core", '>= 5.0.0', '< 7.0.0'
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Hello there! It's been a long time, hum? =)

Another tiny patch: this module is still used on our production servers (almost 1000 ;)), and we're upgrading them from Logstash 5.5 to Logstash 6.8.